### PR TITLE
Add explicitly the name of the LCIO libraries

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -71,7 +71,7 @@ INSTALL( FILES ./include/lccd.h ./include/lccd_exceptions.h DESTINATION include 
 #)
 ADD_SHARED_LIBRARY( ${libname} ${library_sources} )
 INSTALL_SHARED_LIBRARY( ${libname} DESTINATION lib )
-TARGET_LINK_LIBRARIES( ${libname} ${LCIO_LIBRARIES} )
+TARGET_LINK_LIBRARIES( ${libname} LCIO::lcio )
 
 
 # add tests


### PR DESCRIPTION
BEGINRELEASENOTES
- Add explicitly the names of the LCIO libraries to allow builds where the names of the libraries may not be known while configuring LCCD

ENDRELEASENOTES

It's unlikely LCIO libraries change a lot in the future and also it's maybe a better design to only link to what's needed.