### PR TITLE
Fix compilation warnings

### DIFF
--- a/source/src/DBCondHandler.cc
+++ b/source/src/DBCondHandler.cc
@@ -173,16 +173,16 @@ namespace lccd {
 
 #else // not linked with CondDBMysql ========================================================================
 
-  DBCondHandler::DBCondHandler(const std::string& dbInit,  const std::string& folder,
-			       const std::string& name,  const std::string& tag  ) {
+  DBCondHandler::DBCondHandler(const std::string& ,  const std::string& ,
+			       const std::string& ,  const std::string& ) {
 
     throw lccd::DatabaseException("DBCondHandler: cannot instantiate - not linked with CondDBMysql ...." ) ; 
   }
 
   DBCondHandler::~DBCondHandler() {}
-  void DBCondHandler::registerDefaultCollection( lcio::LCCollection* col){}
+  void DBCondHandler::registerDefaultCollection( lcio::LCCollection* ){}
 
-  void DBCondHandler::update( LCCDTimeStamp timeStamp )  {}
+  void DBCondHandler::update( LCCDTimeStamp )  {}
 
 
 #endif // LCCD_CONDDBMYSQL

--- a/source/src/DBFileHandler.cc
+++ b/source/src/DBFileHandler.cc
@@ -18,7 +18,7 @@ namespace lccd {
 
 
   /** Helper predicate to find validity ranges */
-  class contains_timestamp : public std::unary_function<ValidityInterval,bool>{
+  class contains_timestamp {
   public:
     contains_timestamp(LCCDTimeStamp  t) : _t( t) {}  
     bool operator()(const ValidityInterval& v) {
@@ -99,7 +99,7 @@ namespace lccd {
 	_validTill = _valVec[ evtNum ].second  ;    
 	//	std::cout << "DBFileHandler::update: setting validity range:" << _validSince << " " << _validTill << std::endl ;		
 	
-      } catch(lccd::DataNotAvailableException) {
+      } catch(lccd::DataNotAvailableException&) {
 	
 	//	std::cout << "DBFileHandler::update: evtNum not found" << std::endl ;	
 	

--- a/source/src/DBFileHandler.cc
+++ b/source/src/DBFileHandler.cc
@@ -17,18 +17,6 @@ using namespace lcio ;
 namespace lccd {
 
 
-  /** Helper predicate to find validity ranges */
-  class contains_timestamp {
-  public:
-    contains_timestamp(LCCDTimeStamp  t) : _t( t) {}  
-    bool operator()(const ValidityInterval& v) {
-      return ( v.first <= _t && v.second > _t  ) ; 
-    }
-  protected:
-    LCCDTimeStamp  _t ;
-  };
-  
-
   DBFileHandler::DBFileHandler(const std::string& fileName, 
 				       const std::string& name,
 				       const std::string& inputCollection ) : 
@@ -198,15 +186,13 @@ namespace lccd {
   int DBFileHandler::findEventNumber( LCCDTimeStamp timestamp ) {
 
 
-    contains_timestamp contains( timestamp ) ;
-
     int evtNum = -1 ;
 
     // This could probably be made more efficient - good for now ...
     int nVal = _valVec.size() ;
     for( int i=0 ; i< nVal ; i++ ){
 
-      if ( contains( _valVec[i] ) ){
+      if (  _valVec[i].first <= timestamp && timestamp < _valVec[i].second ){
 	evtNum = i ;
 	break ;
       }  

--- a/source/src/lccd.cc
+++ b/source/src/lccd.cc
@@ -48,9 +48,7 @@ namespace lccd{
 
 
 
-  LCCDTimeStamp fromSimpleTime( const SimpleTime& st ) {
-    // silence possible warning about unused parameter
-    (void)st;
+  LCCDTimeStamp fromSimpleTime( [[maybe_unused]] const SimpleTime& st ) {
 
 #ifdef LCCD_CONDDBMYSQL
     // subtract the ns from 1.1.1900 to 1.1.1970 

--- a/source/src/lccd.cc
+++ b/source/src/lccd.cc
@@ -49,6 +49,8 @@ namespace lccd{
 
 
   LCCDTimeStamp fromSimpleTime( const SimpleTime& st ) {
+    // silence possible warning about unused parameter
+    (void)st;
 
 #ifdef LCCD_CONDDBMYSQL
     // subtract the ns from 1.1.1900 to 1.1.1970 


### PR DESCRIPTION
BEGINRELEASENOTES
- Fix compilation warnings

ENDRELEASENOTES

All trivial ones except the `std::unary_function` which I changed to a simple if since it's only used once and the if is simpler