### PR TITLE
Compile on MacOS by adding ARM64 to Xdr.cc and removing binary_function

### DIFF
--- a/source/src/DBInterface.cc
+++ b/source/src/DBInterface.cc
@@ -29,7 +29,6 @@
 
 #include <memory>
 #include <algorithm>
-#include <functional>
 #include <stdlib.h>
 #include <iomanip>
 
@@ -39,7 +38,7 @@
 namespace lccd {
   
   /** Helper class to sort collections of conditions data w.r.t. to their validity time intervall */
-  struct less_wrt_validity : public binary_function<lcio::LCCollection*,lcio::LCCollection*,bool>{
+  struct less_wrt_validity {
     bool operator() (lcio::LCCollection*  c0, lcio::LCCollection* c1) const {
       return ( std::atoll( c0->parameters().getStringVal(lccd::DBSINCE).c_str() ) <
 	       std::atoll( c1->parameters().getStringVal(lccd::DBSINCE).c_str() ) ) ;

--- a/source/src/Xdr.cc
+++ b/source/src/Xdr.cc
@@ -2,15 +2,13 @@
 
 #include"lccd/Xdr.hh"
 
-#include <iostream>
-
 namespace lccd{
 
   //------------------------------------------
   // Code copied from SIO_functions.
   //------------------------------------------
 
-#if defined(__alpha__) ||   defined(__i386__)  ||   defined(_M_ALPHA)  ||   defined(_M_IX86) || defined(__x86_64__)
+#if defined(__alpha__) ||   defined(__i386__)  ||   defined(_M_ALPHA)  ||   defined(_M_IX86) || defined(__x86_64__) || defined(__aarch64__)
 #define XDR_LITTLE_ENDIAN
 #endif
   


### PR DESCRIPTION
BEGINRELEASENOTES
- Compile on MacOS by adding ARM64 to Xdr.cc and removing binary_function (removed in C++17)

ENDRELEASENOTES

Having a tag after this PR would be great, then I don't need to patch the recipe :)