### PR TITLE
Bump the minimum version of CMake to 3.10, to be able to compile with CMake 4.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 ######################################################
 # cmake file for building LCCD
 # @author Jan Engels, DESY
-CMAKE_MINIMUM_REQUIRED( VERSION 2.6 FATAL_ERROR )
+CMAKE_MINIMUM_REQUIRED( VERSION 3.5 FATAL_ERROR )
 ######################################################
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 ######################################################
 # cmake file for building LCCD
 # @author Jan Engels, DESY
-CMAKE_MINIMUM_REQUIRED( VERSION 3.5 FATAL_ERROR )
+CMAKE_MINIMUM_REQUIRED( VERSION 3.10 FATAL_ERROR )
 ######################################################
 
 

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -8,11 +8,6 @@ INCLUDE_DIRECTORIES( BEFORE "${PROJECT_SOURCE_DIR}/source/include" )
 INCLUDE_DIRECTORIES( ${PROJECT_BINARY_DIR} )
 
 
-# omit warning about preprocessor definitions being escaped
-IF(COMMAND CMAKE_POLICY)
-    CMAKE_POLICY(SET CMP0005 OLD)
-ENDIF()
-
 # specific LCCD variable
 IF( NOT LCCD_DB_INIT )
     SET( LCCD_DB_INIT "localhost:lccd_test:calvin:hobbes" )
@@ -24,7 +19,7 @@ SET( LCCD_DB_INIT "${LCCD_DB_INIT}" CACHE STRING "DB initialization" FORCE )
 #----- need long long for int64 for now ------
 #FIXME: should establish wether we are on a 32bit or 64 bit machine ....
 #ADD_DEFINITIONS( "-Wno-long-long" )
-ADD_DEFINITIONS( "-DLCCD_DB_INIT_DEFAULT=\\\"${LCCD_DB_INIT}\\\"" )
+ADD_DEFINITIONS( "-DLCCD_DB_INIT_DEFAULT=\"${LCCD_DB_INIT}\"" )
 
 
 FILE( GLOB lccd_headers RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}" "./include/lccd/*.h?" )


### PR DESCRIPTION
BEGINRELEASENOTES
- Bump the minimum version of CMake to 3.10, to be able to compile with CMake 4.0
- Don't set CMP0005 to OLD since it has to be set to NEW with CMake 4.0 and onwards. Escape 
the `DLCCD_DB_INIT_DEFAULT` definition accordingly

ENDRELEASENOTES
  
See https://cmake.org/cmake/help/latest/release/4.0.html#deprecated-and-removed-features

Here I'm not sure what's best. I added the following:
```
get_directory_property(COMPILE_DEFINITIONS COMPILE_DEFINITIONS)
message(WARNING "Current definitions: ${COMPILE_DEFINITIONS}")
```
after `DLCCD_DB_INIT_DEFAULT` is set and I get an empty string in the current version, while with this PR it will become
```
Current definitions:
LCCD_DB_INIT_DEFAULT="localhost:lccd_test:calvin:hobbes"
```
I see this is only used in https://github.com/iLCSoft/LCCD/blob/master/source/src/lccd.cc#L44. One possibility would be to remove the definition and just return an empty string, which is the current behaviour.